### PR TITLE
Modified code in HelloWorldScene to actually use the ad listener interface

### DIFF
--- a/Classes/HelloWorldScene.cpp
+++ b/Classes/HelloWorldScene.cpp
@@ -190,67 +190,70 @@ bool HelloWorld::init() {
     const char *apiKey = "r7BmFo";
     chocolateInit(apiKey); // initialize chocolate platform
 
+	setInterstitialListener(this);
+	setRewardedListener(this);
+
     return true;
 }
 
 
-void HelloWorld::interstitialAdLoaded() {
+void HelloWorld::adLoadedInterstitial() {
     CCLOG("interstitialAdLoaded");
     this->setButtonVisible(true, ShowInterestialAdButtonTag);
     this->setButtonVisible(false, LoadInterestialAdButtonTag);
 }
 
-void HelloWorld::interstitialAdShown() {
+void HelloWorld::adShownInterstitial() {
     CCLOG("interstitialAdShown");
 }
 
-void HelloWorld::interstitialAdFailed() {
+void HelloWorld::adFailedInterstitial() {
     CCLOG("interstitialAdFailed");
     this->setButtonVisible(false, ShowInterestialAdButtonTag);
     this->setButtonVisible(true, LoadInterestialAdButtonTag);
 }
 
-void HelloWorld::interstitialAdDismissed() {
+void HelloWorld::adDismissedInterstitial() {
     CCLOG("interstitialAdDismissed");
     this->setButtonVisible(false, ShowInterestialAdButtonTag);
     this->setButtonVisible(true, LoadInterestialAdButtonTag);
 }
 
-void HelloWorld::interstitialAdClicked() {
+void HelloWorld::adClickedInterstitial() {
     CCLOG("interstitialAdClicked");
 }
 
-void HelloWorld::rewardAdLoaded() {
+void HelloWorld::adLoadedRewarded() {
     CCLOG("rewardAdLoaded");
 
     this->setButtonVisible(true, ShowRewardAdButtonTag);
     this->setButtonVisible(false, LoadRewardAdButtonTag);
 }
 
-void HelloWorld::rewardAdFailed() {
+void HelloWorld::adFailedRewarded() {
     CCLOG("rewardAdFailed");
     this->setButtonVisible(false, ShowRewardAdButtonTag);
     this->setButtonVisible(true, LoadRewardAdButtonTag);
 
 }
 
-void HelloWorld::rewardAdCompleted() {
+void HelloWorld::adCompletedRewarded() {
     CCLOG("rewardAdCompleted");
     this->setButtonVisible(false, ShowRewardAdButtonTag);
     this->setButtonVisible(true, LoadRewardAdButtonTag);
 }
 
-void HelloWorld::rewardAdShown() {
+void HelloWorld::adShownRewarded() {
     CCLOG("rewardAdShown");
 }
 
-void HelloWorld::rewardAdShownError() {
+void HelloWorld::adShownErrorRewarded() {
     CCLOG("rewardAdShownError");
     this->setButtonVisible(false, ShowRewardAdButtonTag);
     this->setButtonVisible(true, LoadRewardAdButtonTag);
 }
 
-void HelloWorld::rewardAdDismissed() {
+void HelloWorld::adDismissedRewarded() {
     CCLOG("rewardAdDismissed");
 
     this->setButtonVisible(false, ShowRewardAdButtonTag);

--- a/Classes/HelloWorldScene.h
+++ b/Classes/HelloWorldScene.h
@@ -5,42 +5,34 @@
 #include <ui/UIButton.h>
 #include "cocos2d.h"
 #include "VdopiaAdNativeAPI.h"
+#include "VdopiaInterstitialListener.h"
+#include "VdopiaRewardedListener.h"
 
-class HelloWorld : public cocos2d::Scene {
+class HelloWorld : public cocos2d::Scene,
+		           public VdopiaInterstitialListener,
+		           public VdopiaRewardedListener {
 public:
     static cocos2d::Scene *createScene();
 
-    virtual bool init();
+    bool init() override;
 
     // a selector callback
     void menuCloseCallback(cocos2d::Ref *pSender);
 
     // Interstitial Ad Methods & Callbacks
-
-    void interstitialAdLoaded();
-
-    void interstitialAdFailed();
-
-    void interstitialAdDismissed();
-
-    void interstitialAdClicked();
-
-    void interstitialAdShown();
-
+  	void adLoadedInterstitial() override;
+    void adFailedInterstitial() override; 
+    void adDismissedInterstitial() override; 
+    void adClickedInterstitial() override; 
+    void adShownInterstitial() override; 
 
     // Rewarded Ad Methods & Callbacks
-
-    void rewardAdLoaded();
-
-    void rewardAdFailed();
-
-    void rewardAdDismissed();
-
-    void rewardAdShownError();
-
-    void rewardAdCompleted();
-
-    void rewardAdShown();
+	void adLoadedRewarded() override;
+	void adFailedRewarded() override;
+	void adDismissedRewarded()  override;
+	void adCompletedRewarded() override;
+	void adShownErrorRewarded() override;
+	void adShownRewarded() override;
 
     // implement the "static create()" method manually
     CREATE_FUNC(HelloWorld);

--- a/Classes/HelloWorldScene.h
+++ b/Classes/HelloWorldScene.h
@@ -20,19 +20,19 @@ public:
     void menuCloseCallback(cocos2d::Ref *pSender);
 
     // Interstitial Ad Methods & Callbacks
-  	void adLoadedInterstitial() override;
+    void adLoadedInterstitial() override;
     void adFailedInterstitial() override; 
     void adDismissedInterstitial() override; 
     void adClickedInterstitial() override; 
     void adShownInterstitial() override; 
 
     // Rewarded Ad Methods & Callbacks
-	void adLoadedRewarded() override;
-	void adFailedRewarded() override;
-	void adDismissedRewarded()  override;
-	void adCompletedRewarded() override;
-	void adShownErrorRewarded() override;
-	void adShownRewarded() override;
+    void adLoadedRewarded() override;
+    void adFailedRewarded() override;
+    void adDismissedRewarded()  override;
+    void adCompletedRewarded() override;
+    void adShownErrorRewarded() override;
+    void adShownRewarded() override;
 
     // implement the "static create()" method manually
     CREATE_FUNC(HelloWorld);

--- a/Classes/VdopiaInterstitialListener.h
+++ b/Classes/VdopiaInterstitialListener.h
@@ -3,8 +3,6 @@
 
 class VdopiaInterstitialListener {
 public:
-	VdopiaInterstitialListener();
-
 	virtual void adLoadedInterstitial() = 0;
 	virtual void adFailedInterstitial() = 0;
 	virtual void adDismissedInterstitial() = 0;

--- a/Classes/VdopiaRewardedListener.h
+++ b/Classes/VdopiaRewardedListener.h
@@ -3,8 +3,6 @@
 
 class VdopiaRewardedListener {
 public:
-	VdopiaRewardedListener();
-
 	virtual void adLoadedRewarded() = 0;
 	virtual void adFailedRewarded() = 0;
 	virtual void adDismissedRewarded() = 0;


### PR DESCRIPTION
I thought In the previous commit I changed the code in HelloWorldScene to make calls to
the setListener() function, but I guess I forgot to add those files to my commit.

Anyway, now in the sample the Scene implements the interface and calls the setListener functions accordingly.